### PR TITLE
Wb 1076 moka odeme sonrasi dinamik yonlendirme ozelligi eklendi

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ MOKA_PASSWORD=your-password
 MOKA_SANDBOX_MODE=true
 
 # Optional: Configure redirect URLs
-MOKA_PAYMENT_SUCCESS_URL=/payment/success
-MOKA_PAYMENT_FAILURE_URL=/payment/failed
+MOKA_PAYMENT_SUCCESS_URL=/moka-payment/success
+MOKA_PAYMENT_FAILURE_URL=/moka-payment/failed
 ```
 
 ## Usage
@@ -114,8 +114,8 @@ The package automatically sets up a callback route at `POST /moka-callback` (nam
 You can configure the success and failure URLs in your `.env` file:
 
 ```env
-MOKA_PAYMENT_SUCCESS_URL=/payment/success
-MOKA_PAYMENT_FAILURE_URL=/payment/failure
+MOKA_PAYMENT_SUCCESS_URL=/moka-payment/success
+MOKA_PAYMENT_FAILURE_URL=/moka-payment/failure
 ```
 
 The callback will redirect to these URLs with the following session data:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ MOKA_SANDBOX_MODE=true
 
 # Optional: Configure redirect URLs
 MOKA_PAYMENT_SUCCESS_URL=/payment/success
-MOKA_PAYMENT_FAILED_URL=/payment/failed
+MOKA_PAYMENT_FAILURE_URL=/payment/failed
 ```
 
 ## Usage
@@ -115,7 +115,7 @@ You can configure the success and failure URLs in your `.env` file:
 
 ```env
 MOKA_PAYMENT_SUCCESS_URL=/payment/success
-MOKA_PAYMENT_FAILED_URL=/payment/failed
+MOKA_PAYMENT_FAILURE_URL=/payment/failure
 ```
 
 The callback will redirect to these URLs with the following session data:

--- a/config/moka.php
+++ b/config/moka.php
@@ -44,5 +44,5 @@ return [
     |
     */
     'payment_success_url' => env('MOKA_PAYMENT_SUCCESS_URL', '/payment/success'),
-    'payment_failed_url' => env('MOKA_PAYMENT_FAILED_URL', '/payment/failed'),
+    'payment_failure_url' => env('MOKA_PAYMENT_FAILURE_URL', '/payment/failure'),
 ];

--- a/config/moka.php
+++ b/config/moka.php
@@ -43,6 +43,6 @@ return [
     | in your application's config file.
     |
     */
-    'payment_success_url' => env('MOKA_PAYMENT_SUCCESS_URL', '/payment/success'),
-    'payment_failure_url' => env('MOKA_PAYMENT_FAILURE_URL', '/payment/failure'),
+    'payment_success_url' => env('MOKA_PAYMENT_SUCCESS_URL', '/moka-payment/success'),
+    'payment_failure_url' => env('MOKA_PAYMENT_FAILURE_URL', '/moka-payment/failure'),
 ];

--- a/src/Http/Controllers/MokaCallbackController.php
+++ b/src/Http/Controllers/MokaCallbackController.php
@@ -28,9 +28,9 @@ class MokaCallbackController extends Controller
             : ($request->query('failure_url') ?: config('moka.payment_failure_url'));
 
         return redirect($redirectUrl)->with([
-                                                'other_trx_code' => $payment->other_trx_code,
-                                                'status' => $isSuccess ? 'success' : 'failed',
-                                                'message' => $payment->result_message,
-                                            ]);
+            'other_trx_code' => $payment->other_trx_code,
+            'status' => $isSuccess ? 'success' : 'failed',
+            'message' => $payment->result_message,
+        ]);
     }
 }

--- a/src/Http/Controllers/MokaCallbackController.php
+++ b/src/Http/Controllers/MokaCallbackController.php
@@ -22,12 +22,15 @@ class MokaCallbackController extends Controller
         );
 
         $isSuccess = $payment->status === MokaPaymentStatus::SUCCESS;
-        $redirectUrl = $isSuccess ? config('moka.payment_success_url') : config('moka.payment_failed_url');
+
+        $redirectUrl = $isSuccess
+            ? ($request->query('success_url') ?: config('moka.payment_success_url'))
+            : ($request->query('failure_url') ?: config('moka.payment_failure_url'));
 
         return redirect($redirectUrl)->with([
-            'other_trx_code' => $payment->other_trx_code,
-            'status' => $isSuccess ? 'success' : 'failed',
-            'message' => $payment->result_message,
-        ]);
+                                                'other_trx_code' => $payment->other_trx_code,
+                                                'status' => $isSuccess ? 'success' : 'failed',
+                                                'message' => $payment->result_message,
+                                            ]);
     }
 }

--- a/tests/Feature/MokaCallbackControllerTest.php
+++ b/tests/Feature/MokaCallbackControllerTest.php
@@ -45,7 +45,7 @@ it('redirects to failed URL with correct parameters when payment fails', functio
     $controller = new MokaCallbackController;
     $response = $controller->handle3D($request);
 
-    expect($response->getTargetUrl())->toBe(url(config('moka.payment_failed_url')));
+    expect($response->getTargetUrl())->toBe(url(config('moka.payment_failure_url')));
     expect(session('other_trx_code'))->toBe('12345');
     expect(session('status'))->toBe('failed');
     expect(session('message'))->toBe('Failed');


### PR DESCRIPTION
Modified the callback controller to use `success_url` and `failure_url` query parameters if available, falling back to config defaults. Ensures more flexibility in specifying redirection URLs dynamically.