### PR TITLE
WB-1081: Refactor redirect logic in MokaCallbackController.

### DIFF
--- a/src/Http/Controllers/MokaCallbackController.php
+++ b/src/Http/Controllers/MokaCallbackController.php
@@ -23,14 +23,13 @@ class MokaCallbackController extends Controller
 
         $isSuccess = $payment->status === MokaPaymentStatus::SUCCESS;
 
-        $redirectUrl = $isSuccess
-            ? ($request->query('success_url') ?: config('moka.payment_success_url'))
-            : ($request->query('failure_url') ?: config('moka.payment_failure_url'));
+        $baseUrl = $isSuccess
+            ? ($request->query(key: 'success_url') ?: config(key: 'moka.payment_success_url'))
+            : ($request->query(key: 'failure_url') ?: config(key: 'moka.payment_failed_url'));
 
-        return redirect($redirectUrl)->with([
-            'other_trx_code' => $payment->other_trx_code,
-            'status' => $isSuccess ? 'success' : 'failed',
-            'message' => $payment->result_message,
-        ]);
+        $separator = (str_contains($baseUrl, '?')) ? '&' : '?';
+        $redirectUrl = "$baseUrl{$separator}other_trx_code={$payment->other_trx_code}";
+
+        return redirect($redirectUrl);
     }
 }


### PR DESCRIPTION
# Add payment reference as query parameter to redirect URL

This PR modifies the Moka callback handler to append the `other_trx_code` as a query parameter to the redirect URL, rather than trying to pass it through session data.

## Why?
- In cross-domain redirects (from backend to frontend), session data is lost
- The previous implementation using `with()` method only works within the same domain
- Frontend applications need the transaction reference to verify and display payment results

## Changes

- Removed `with()` method that was storing data in session
- Added logic to append `other_trx_code` directly to the redirect URL as a query parameter
- Used proper URL building with separator detection (`?` or `&`)

This change ensures the frontend application receives the necessary payment reference regardless of domain differences, allowing for proper handling of payment results.




