### PR TITLE
Fire Events for After Callback

### DIFF
--- a/src/Events/MokaPaymentEvent.php
+++ b/src/Events/MokaPaymentEvent.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tarfin\Moka\Events;
+
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+use Tarfin\Moka\Models\MokaPayment;
+
+abstract class MokaPaymentEvent
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(
+        public MokaPayment $mokaPayment,
+    ) {}
+}

--- a/src/Events/MokaPaymentFailed.php
+++ b/src/Events/MokaPaymentFailed.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tarfin\Moka\Events;
+
+class MokaPaymentFailed extends MokaPaymentEvent {}

--- a/src/Events/MokaPaymentSucceeded.php
+++ b/src/Events/MokaPaymentSucceeded.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tarfin\Moka\Events;
+
+class MokaPaymentSucceeded extends MokaPaymentEvent {}


### PR DESCRIPTION
This PR adds event dispatching for Moka payment outcomes. Successful payments trigger a `MokaPaymentSucceeded` event while failed payments trigger a `MokaPaymentFailed` event, allowing applications to listen and react accordingly:

```php
match ($status) {
    MokaPaymentStatus::SUCCESS => MokaPaymentSucceeded::dispatch($this),
    MokaPaymentStatus::FAILED => MokaPaymentFailed::dispatch($this),
};
```