### PR TITLE
Wb 1489 kk islemlerinde basarili basarisiz islem kayitlarinin ekiplere gosterilmesi

### DIFF
--- a/database/migrations/2025_07_31_000001_add_bank_columns_to_moka_payments_table.php
+++ b/database/migrations/2025_07_31_000001_add_bank_columns_to_moka_payments_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::table('moka_payments', function (Blueprint $table): void {
+            $table->string('bank_name')->nullable()->after('card_last_four');
+            $table->string('bank_group_name')->nullable()->after('bank_name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('moka_payments', function (Blueprint $table): void {
+            $table->dropColumn(['bank_name', 'bank_group_name']);
+        });
+    }
+};

--- a/src/Models/MokaPayment.php
+++ b/src/Models/MokaPayment.php
@@ -21,6 +21,8 @@ class MokaPayment extends Model
         'card_holder',
         'card_type',
         'card_last_four',
+        'bank_name',
+        'bank_group_name',
         'code_for_hash',
         'status',
         'amount',

--- a/src/Services/Payment/MokaPaymentThreeD.php
+++ b/src/Services/Payment/MokaPaymentThreeD.php
@@ -97,6 +97,8 @@ class MokaPaymentThreeD extends MokaRequest
             'other_trx_code'    => $paymentData['PaymentDealerRequest']['OtherTrxCode'],
             'card_type'         => $cardInfo['card_type'],
             'card_last_four'    => $cardInfo['card_last_four'],
+            'bank_name'         => $cardInfo['bank_name'],
+            'bank_group_name'   => $cardInfo['bank_group_name'],
             'card_holder'       => $cardHolderName,
             'amount'            => $amount,
             'amount_charged'    => $chargedAmount,
@@ -157,8 +159,10 @@ class MokaPaymentThreeD extends MokaRequest
         $response  = Moka::binInquiry()->get($binNumber);
 
         return [
-            'card_type'      => $response['CardType'],
-            'card_last_four' => substr($cardNumber, -4),
+            'card_type'       => $response['CardType'],
+            'card_last_four'  => substr($cardNumber, -4),
+            'bank_name'       => $response['BankName'] ?? null,
+            'bank_group_name' => $response['GroupName'] ?? null,
         ];
     }
 }

--- a/tests/Feature/MokaPaymentThreeDTest.php
+++ b/tests/Feature/MokaPaymentThreeDTest.php
@@ -197,8 +197,8 @@ it('throws exception when payment creation fails', function (): void {
         expMonth: '12',
         expYear: '2025',
         cvc: '123',
-        returnUrl: 'https://your-site.com/moka-callback',
-        software: 'Tarfin'
+        software: 'Tarfin',
+        returnUrl: 'https://your-site.com/moka-callback'
     ))->toThrow(function (MokaPaymentThreeDException $exception): void {
         expect($exception->getMessage())->toBe(__('moka::payment-three-d.PaymentDealer.CheckCardInfo.InvalidCardInfo'))
             ->and($exception->getCode())->toBe('PaymentDealer.CheckCardInfo.InvalidCardInfo');
@@ -230,24 +230,26 @@ it('stores payment data in database when payment is successful', function (): vo
         expMonth: '12',
         expYear: '2025',
         cvc: '123',
+        software: 'Tarfin',
         returnUrl: 'https://your-site.com/moka-callback',
         installment: 3,
-        software: 'Tarfin',
         otherTrxCode: $otherTrxCode
     );
 
     $this->assertDatabaseHas('moka_payments', [
-        'other_trx_code' => $otherTrxCode,
-        'code_for_hash'  => 'test-hash-code',
-        'amount'         => 100.00,
-        'installment'    => 3,
-        'status'         => MokaPaymentStatus::PENDING->value,
-        'result_code'    => 'Success',
-        'result_message' => '',
-        'three_d'        => 1,
-        'card_holder'    => 'John Doe',
-        'card_type'      => 'MASTER',
-        'card_last_four' => '5555',
+        'other_trx_code'  => $otherTrxCode,
+        'code_for_hash'   => 'test-hash-code',
+        'amount'          => 100.00,
+        'installment'     => 3,
+        'status'          => MokaPaymentStatus::PENDING->value,
+        'result_code'     => 'Success',
+        'result_message'  => '',
+        'three_d'         => 1,
+        'card_holder'     => 'John Doe',
+        'card_type'       => 'MASTER',
+        'card_last_four'  => '5555',
+        'bank_name'       => 'FİNANSBANK',
+        'bank_group_name' => 'CARDFINANS',
     ]);
 });
 
@@ -282,15 +284,17 @@ it('stores failed payment data in database when enabled in config', function ():
         );
     } catch (MokaPaymentThreeDException $e) {
         $this->assertDatabaseHas('moka_payments', [
-            'other_trx_code' => $otherTrxCode,
-            'amount'         => 100.00,
-            'status'         => MokaPaymentStatus::FAILED->value,
-            'result_code'    => 'PaymentDealer.CheckCardInfo.InvalidCardInfo',
-            'result_message' => __('moka::payment-three-d.PaymentDealer.CheckCardInfo.InvalidCardInfo'),
-            'three_d'        => 1,
-            'card_holder'    => 'John Doe',
-            'card_type'      => 'MASTER',
-            'card_last_four' => '5555',
+            'other_trx_code'  => $otherTrxCode,
+            'amount'          => 100.00,
+            'status'          => MokaPaymentStatus::FAILED->value,
+            'result_code'     => 'PaymentDealer.CheckCardInfo.InvalidCardInfo',
+            'result_message'  => __('moka::payment-three-d.PaymentDealer.CheckCardInfo.InvalidCardInfo'),
+            'three_d'         => 1,
+            'card_holder'     => 'John Doe',
+            'card_type'       => 'MASTER',
+            'card_last_four'  => '5555',
+            'bank_name'       => 'FİNANSBANK',
+            'bank_group_name' => 'CARDFINANS',
         ]);
     }
 });

--- a/tests/Unit/MokaPaymentThreeDTest.php
+++ b/tests/Unit/MokaPaymentThreeDTest.php
@@ -29,7 +29,9 @@ test('getCardInfo returns correct card information', function (): void {
     $result     = Moka::threeDPayment()->getCardInfo($cardNumber);
 
     expect($result)->toBe([
-        'card_type'      => 'MASTER',
-        'card_last_four' => '5555',
+        'card_type'       => 'MASTER',
+        'card_last_four'  => '5555',
+        'bank_name'       => 'FİNANSBANK',
+        'bank_group_name' => 'CARDFINANS',
     ]);
 });


### PR DESCRIPTION
### Added

- WB-1489: Add `bank_name` and `bank_group_name` columns to `moka_payments` table and model
- WB-1489: Include `bank_name` and `bank_group_name` in MokaPaymentThreeD processing
- WB-1489: Add assertions for `bank_name` and `bank_group_name` in MokaPaymentThreeD tests